### PR TITLE
Fast skip of SSE encoding / decoding

### DIFF
--- a/source/gfoidl.Base64/Base64Encoder.Decode.cs
+++ b/source/gfoidl.Base64/Base64Encoder.Decode.cs
@@ -115,9 +115,9 @@ namespace gfoidl.Base64
 
 #if NETCOREAPP
 #if NETCOREAPP3_0
-            if (Ssse3.IsSupported && srcLength >= 24)
+            if (Ssse3.IsSupported && (srcLength - sourceIndex >= 24))
 #else
-            if (Sse2.IsSupported && Ssse3.IsSupported && srcLength >= 24)
+            if (Sse2.IsSupported && Ssse3.IsSupported && (srcLength - sourceIndex >= 24))
 #endif
             {
                 if (!Sse2Decode(ref src, ref destBytes, srcLength, ref sourceIndex, ref destIndex))

--- a/source/gfoidl.Base64/Base64Encoder.Encode.cs
+++ b/source/gfoidl.Base64/Base64Encoder.Encode.cs
@@ -104,9 +104,9 @@ namespace gfoidl.Base64
 
 #if NETCOREAPP
 #if NETCOREAPP3_0
-            if (Ssse3.IsSupported && srcLength >= 16)
+            if (Ssse3.IsSupported && (srcLength - 16 >= sourceIndex))
 #else
-            if (Sse2.IsSupported && Ssse3.IsSupported && srcLength >= 16)
+            if (Sse2.IsSupported && Ssse3.IsSupported && (srcLength - 16 >= sourceIndex))
 #endif
             {
                 Sse2Encode(ref srcBytes, ref dest, srcLength, ref sourceIndex, ref destIndex);


### PR DESCRIPTION
In current _master_ all the simd-constants are loaded before the check for work is done,
https://github.com/gfoidl/Base64/blob/057a8d85ee499e68abc02e7c7894b4eeb4c2f561/source/gfoidl.Base64/Base64Encoder.Encode.cs#L248-L259, this is no short-circuited. 