### PR TITLE
`Base64.Internal.Array` is now `internal`

### DIFF
--- a/source/gfoidl.Base64/Internal/MissingApisExtension.cs
+++ b/source/gfoidl.Base64/Internal/MissingApisExtension.cs
@@ -1,7 +1,7 @@
 ﻿#if NET45
 namespace gfoidl.Base64.Internal
 {
-    public static class Array
+    internal static class Array
     {
         public static T[] Empty<T>() => EmptyArray<T>.s_value;
         //---------------------------------------------------------------------


### PR DESCRIPTION
Fix #165

`gfoidl.Base64.Internal.Array` as public may cause conflicts with `System.Array` on TFM net47 if:
 - The namespace `gfoidl.Base64.Internal` is in the `using` definition 
**AND**
 - The type `System.Array`is used in this file

Switching from `public` to `internal` this type resolve the issue without impact.


Note: It may be possible now to change the namespace from `gfoidl.Base64.Internal` to `System`